### PR TITLE
Add basic type checking on instance doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+UNRELEASED
+
+* Add basic `instance_double` verification to help check the type of an instance double.
+
 1.0.0
 
 * Initial release

--- a/lib/rspec/sorbet/instance_doubles.rb
+++ b/lib/rspec/sorbet/instance_doubles.rb
@@ -5,11 +5,6 @@ require 'sorbet-runtime'
 module RSpec
   module Sorbet
     module InstanceDoubles
-      WHITELISTED_ERROR_MESSAGES = [
-        'RSpec::Mocks::InstanceVerifyingDouble',
-        'InstanceDouble'
-      ].freeze
-
       def allow_instance_doubles!
         T::Configuration.inline_type_error_handler = proc do |error|
           inline_type_error_handler(error)
@@ -22,18 +17,73 @@ module RSpec
 
       private
 
+      INLINE_INSTANCE_DOUBLE_REGEX =
+        /T.let: Expected type (T.any\()?(?<expected_classes>[a-zA-Z:: ,]*)(\))?, got type (.*) with value #<InstanceDouble\((?<doubled_module>[a-zA-Z:: ,]*)\)/.freeze
+
       def inline_type_error_handler(error)
-        raise error unless error.is_a?(TypeError) && message_is_whitelisted?(error.message)
+        case error
+        when TypeError
+          message = error.message
+          return if instance_double_message_with_ellipsis?(message) || typed_array_message?(message)
+
+          _, expected_types_string, doubled_module_string = (message.match(INLINE_INSTANCE_DOUBLE_REGEX) || [])[0..2]
+          raise error unless expected_types_string && doubled_module_string
+
+          expected_types = expected_types_string.split(',').map do |expected_type_string|
+            Object.const_get(expected_type_string.strip)
+          end
+          doubled_module = Object.const_get(doubled_module_string)
+
+          valid = expected_types.any? do |expected_type|
+            doubled_module.ancestors.include?(expected_type)
+          end
+
+          raise error unless valid
+        else
+          raise error
+        end
+      end
+
+      INSTANCE_VERIFYING_DOUBLE_OR_INSTANCE_DOUBLE =
+        /(RSpec::Mocks::InstanceVerifyingDouble|InstanceDouble)/.freeze
+
+      def instance_double_message_with_ellipsis?(message)
+        message.include?('...') && message.match?(INSTANCE_VERIFYING_DOUBLE_OR_INSTANCE_DOUBLE)
+      end
+
+      TYPED_ARRAY_MESSAGE = /got T::Array/.freeze
+
+      def typed_array_message?(message)
+        message.match?(TYPED_ARRAY_MESSAGE)
       end
 
       def call_validation_error_handler(_signature, opts)
-        raise TypeError, opts[:pretty_message] unless message_is_whitelisted?(opts[:message])
-      end
+        should_raise = true
 
-      def message_is_whitelisted?(message)
-        WHITELISTED_ERROR_MESSAGES.any? do |whitelisted_message|
-          message.include?(whitelisted_message)
+        if opts[:pretty_message].match?(INSTANCE_VERIFYING_DOUBLE_OR_INSTANCE_DOUBLE)
+          typing = opts[:type]
+          value = opts[:value].is_a?(Array) ? opts[:value].first : opts[:value]
+          target = value.instance_variable_get(:@doubled_module).target
+
+          case typing
+          when T::Types::TypedArray
+            typing = typing.type
+          end
+
+          case typing
+          when T::Types::Simple
+            should_raise = !target.ancestors.include?(typing.raw_type)
+          when T::Types::Union
+            valid = typing.types.map(&:raw_type).any? do |type|
+              target.ancestors.include?(type)
+            end
+            should_raise = !valid
+          else
+            should_raise = !target.ancestors.include?(typing)
+          end
         end
+
+        raise TypeError, opts[:pretty_message] if should_raise
       end
     end
   end

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -7,14 +7,57 @@ module RSpec
     describe '.allow_instance_doubles!' do
       subject(:allow_instance_doubles!) { described_class.allow_instance_doubles! }
 
-      context 'when an instance double is used' do
-        let(:my_instance_double) { instance_double(String) }
+      class Person
+        extend T::Sig
 
-        specify do
-          expect { T.let(my_instance_double, String) }.to raise_error(TypeError)
-          allow_instance_doubles!
-          expect { T.let(my_instance_double, String) }.not_to raise_error(TypeError)
+        sig{params(forename: String, surname: String).void}
+        def initialize(forename)
+          @forename = T.let(forename, String)
+          @surname = T.let(surname, String)
         end
+
+        sig{returns(String)}
+        def full_name
+          [@forename, @surname].join(' ')
+        end
+      end
+
+      class Greeter
+        extend T::Sig
+
+        sig{params(person: Person).void}
+        def initialize(person)
+          @person = T.let(person, Person)
+        end
+
+        sig{returns(String)}
+        def greet
+          "Hello #{@person.full_name}"
+        end
+      end
+
+      let(:my_instance_double) { instance_double(String) }
+      let(:my_person) do
+        Person.new('Sam', 'Giles')
+      end
+      let(:my_person_double) do
+        instance_double(Person, full_name: 'Steph Giles')
+      end
+
+      specify do
+        expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
+        expect { Greeter.new(my_person_double).greet }.to raise_error(TypeError)
+        expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
+        expect { T.let(my_instance_double, String) }.to raise_error(TypeError)
+        expect { T.let(my_instance_double, Integer) }.to raise_error(TypeError)
+        allow_instance_doubles!
+        expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
+        expect { Greeter.new(my_person_double).greet }.not_to raise_error(TypeError)
+        expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
+        expect { T.let(my_instance_double, String) }.not_to raise_error(TypeError)
+        expect { T.let(my_instance_double, T.any(String, TrueClass)) }.not_to raise_error(TypeError)
+        expect { T.let(my_instance_double, Integer) }.to raise_error(TypeError)
+        expect { T.let(my_instance_double, T.any(Integer, Numeric)) }.to raise_error(TypeError)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
 
+  RSpec::Expectations.configuration.on_potential_false_positives = :nothing
   # Disable RSpec exposing methods globally on `Module` and `main`
   # config.disable_monkey_patching!
 


### PR DESCRIPTION
This PR enhances `.allow_instance_doubles!` by enabling it to do basic type checking against the specified type and the instance_double'd module/class.

Now if your attempting to pass in an `instance_double` that wouldn't otherwise match the type specified a `TypeError` will still be raised:

```ruby
      class Person
        extend T::Sig

        sig{params(forename: String, surname: String).void}
        def initialize(forename)
          @forename = T.let(forename, String)
          @surname = T.let(surname, String)
        end

        sig{returns(String)}
        def full_name
          [@forename, @surname].join(' ')
        end
      end

      class Greeter
        extend T::Sig

        sig{params(person: Person).void}
        def initialize(person)
          @person = T.let(person, Person)
        end

        sig{returns(String)}
        def greet
          "Hello #{@person.full_name}"
        end
      end

...

      
      let(:my_person) do
        Person.new('Sam', 'Giles')
      end
      let(:my_person_double) do
        instance_double(Person, full_name: 'Steph Giles')
      end
      let(:my_other_double) do
        instance_double(TrueClass)
      end

      specify do
        # Calling with the actual Person will work:
        expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
        # Calling with the instance_double of a Person won't work yet:
        expect { Greeter.new(my_person_double).greet }.to raise_error(TypeError)
        # And calling with a completely incorrect type also won't work:
        expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
        # We enable instance doubles
        RSpec::Sorbet.allow_instance_doubles!
        # The actual Person continues to work:
        expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
        # The instance double now works:
        expect { Greeter.new(my_person_double).greet }.not_to raise_error(TypeError)
        # But an instance double of a different type will not work:
        expect { Greeter.new(my_other_double).greet }.to raise_error(TypeError)
        # The string continues not to work:
        expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
      end


```