### PR TITLE
Add support for T::Enumerable

### DIFF
--- a/lib/rspec/sorbet/instance_doubles.rb
+++ b/lib/rspec/sorbet/instance_doubles.rb
@@ -66,7 +66,7 @@ module RSpec
           target = value.instance_variable_get(:@doubled_module).target
 
           case typing
-          when T::Types::TypedArray
+          when T::Types::TypedArray, T::Types::TypedEnumerable
             typing = typing.type
           end
 

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -11,7 +11,7 @@ module RSpec
         extend T::Sig
 
         sig{params(forename: String, surname: String).void}
-        def initialize(forename)
+        def initialize(forename, surname)
           @forename = T.let(forename, String)
           @surname = T.let(surname, String)
         end
@@ -34,6 +34,11 @@ module RSpec
         def greet
           "Hello #{@person.full_name}"
         end
+
+        sig{params(others: T::Enumerable[Person])}
+        def greet_others(others)
+          "Hello #{@person.full_name}, #{others.map(&:full_name).join(', ')}"
+        end
       end
 
       let(:my_instance_double) { instance_double(String) }
@@ -43,6 +48,9 @@ module RSpec
       let(:my_person_double) do
         instance_double(Person, full_name: 'Steph Giles')
       end
+      let(:another_person) do
+        instance_double(Person, full_name: 'Yasmin Collins')
+      end
 
       specify do
         expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
@@ -50,10 +58,14 @@ module RSpec
         expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
         expect { T.let(my_instance_double, String) }.to raise_error(TypeError)
         expect { T.let(my_instance_double, Integer) }.to raise_error(TypeError)
+        expect { Greeter.new(my_person_double).greet_others([my_person_double, another_person]) }
+          .to raise_error(TypeError)
         allow_instance_doubles!
         expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
         expect { Greeter.new(my_person_double).greet }.not_to raise_error(TypeError)
         expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
+        expect { Greeter.new(my_person_double).greet_others([my_person_double, another_person]) }
+          .not_to raise_error(TypeError)
         expect { T.let(my_instance_double, String) }.not_to raise_error(TypeError)
         expect { T.let(my_instance_double, T.any(String, TrueClass)) }.not_to raise_error(TypeError)
         expect { T.let(my_instance_double, Integer) }.to raise_error(TypeError)


### PR DESCRIPTION
This PR adds support for `T::Enumerable` types which behave like `T::Array` types when it comes to the underlying typing.