### PR TITLE
Add lookup for message alongside pretty_message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+UNRELEASED
+
+* Fix call check when opts contains :message instead of :pretty_message.
+
 1.2.0
 
 * Added support for verifying `T::Enumerable` types.

--- a/lib/rspec/sorbet/instance_doubles.rb
+++ b/lib/rspec/sorbet/instance_doubles.rb
@@ -60,7 +60,8 @@ module RSpec
       def call_validation_error_handler(_signature, opts)
         should_raise = true
 
-        if opts[:pretty_message].match?(INSTANCE_VERIFYING_DOUBLE_OR_INSTANCE_DOUBLE)
+        message = opts.fetch(:pretty_message, opts.fetch(:message, ''))
+        if message.match?(INSTANCE_VERIFYING_DOUBLE_OR_INSTANCE_DOUBLE)
           typing = opts[:type]
           value = opts[:value].is_a?(Array) ? opts[:value].first : opts[:value]
           target = value.instance_variable_get(:@doubled_module).target


### PR DESCRIPTION
This PR fixes an issue when the message is present at `:message` instead of `:pretty_message` then fire and flames ensue.