### PR TITLE
Support nilable types for inline types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+UNRELEASED
+
+* Added support for `T.let` referencing `T.nilable` types.
+
 1.3.0
 
 * Added ability to allow any kind of double (Class, Instance, Object).

--- a/lib/rspec/sorbet/doubles.rb
+++ b/lib/rspec/sorbet/doubles.rb
@@ -22,7 +22,7 @@ module RSpec
       private
 
       INLINE_DOUBLE_REGEX =
-        /T.let: Expected type (T.any\()?(?<expected_classes>[a-zA-Z:: ,]*)(\))?, got type (.*) with value #<(Instance|Class|Object)Double\((?<doubled_module>[a-zA-Z:: ,]*)\)/.freeze
+        /T.let: Expected type (T.(any|nilable)\()?(?<expected_classes>[a-zA-Z:: ,]*)(\))?, got type (.*) with value #<(Instance|Class|Object)Double\((?<doubled_module>[a-zA-Z:: ,]*)\)/.freeze
 
       def inline_type_error_handler(error)
         case error

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -18,6 +18,11 @@ module RSpec
         def full_name
           [@forename, @surname].join(' ')
         end
+
+        sig{returns(T.nilable(Person))}
+        def reversed
+          Person.new(@surname, @forename)
+        end
       end
 
       class Greeter
@@ -33,6 +38,11 @@ module RSpec
           "Hello #{@person.full_name}"
         end
 
+        sig{returns(T.nilable(Person))}
+        def reversed
+          T.let(@person.reversed, T.nilable(Person))
+        end
+
         sig{params(others: T::Enumerable[Person])}
         def greet_others(others)
           "Hello #{@person.full_name}, #{others.map(&:full_name).join(', ')}"
@@ -44,7 +54,7 @@ module RSpec
         Person.new('Sam', 'Giles')
       end
       let(:my_person_double) do
-        instance_double(Person, full_name: 'Steph Giles')
+        instance_double(Person, full_name: 'Steph Giles', reversed: another_person)
       end
       let(:another_person) do
         instance_double(Person, full_name: 'Yasmin Collins')
@@ -55,6 +65,7 @@ module RSpec
       specify do
         expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
         expect { Greeter.new(my_person_double).greet }.to raise_error(TypeError)
+        expect { Greeter.new(my_person_double).reversed }.to raise_error(TypeError)
         expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
         expect { T.let(my_instance_double, String) }.to raise_error(TypeError)
         expect { T.let(my_instance_double, Integer) }.to raise_error(TypeError)
@@ -63,6 +74,7 @@ module RSpec
         subject
         expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
         expect { Greeter.new(my_person_double).greet }.not_to raise_error(TypeError)
+        expect { Greeter.new(my_person_double).reversed }.not_to raise_error(TypeError)
         expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
         expect { Greeter.new(my_person_double).greet_others([my_person_double, another_person]) }
           .not_to raise_error(TypeError)


### PR DESCRIPTION
Using a `T.let` that references a `T.nilable` type was raising an error, by reusing the existing support for `T.any` we can also support `T.nilable`.