### PR TITLE
Allow instance_doubles within T.cast calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+UNRELEASED
+
+* Added support for `T.cast`.
+
 1.4.0
 
 * Added support for `T.let` referencing `T.nilable` types.

--- a/lib/rspec/sorbet/doubles.rb
+++ b/lib/rspec/sorbet/doubles.rb
@@ -22,7 +22,7 @@ module RSpec
       private
 
       INLINE_DOUBLE_REGEX =
-        /T.let: Expected type (T.(any|nilable)\()?(?<expected_classes>[a-zA-Z:: ,]*)(\))?, got type (.*) with value #<(Instance|Class|Object)Double\((?<doubled_module>[a-zA-Z:: ,]*)\)/.freeze
+        /T.(let|cast): Expected type (T.(any|nilable)\()?(?<expected_classes>[a-zA-Z:: ,]*)(\))?, got type (.*) with value #<(Instance|Class|Object)Double\((?<doubled_module>[a-zA-Z:: ,]*)\)/.freeze
 
       def inline_type_error_handler(error)
         case error

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -38,6 +38,11 @@ module RSpec
           "Hello #{@person.full_name}"
         end
 
+        sig{returns(Person)}
+        def person
+          T.cast(@person, Person)
+        end
+
         sig{returns(T.nilable(Person))}
         def reversed
           T.let(@person.reversed, T.nilable(Person))
@@ -66,6 +71,7 @@ module RSpec
         expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
         expect { Greeter.new(my_person_double).greet }.to raise_error(TypeError)
         expect { Greeter.new(my_person_double).reversed }.to raise_error(TypeError)
+        expect { Greeter.new(my_person_double).person }.to raise_error(TypeError)
         expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
         expect { T.let(my_instance_double, String) }.to raise_error(TypeError)
         expect { T.let(my_instance_double, Integer) }.to raise_error(TypeError)
@@ -75,6 +81,7 @@ module RSpec
         expect { Greeter.new(my_person).greet }.not_to raise_error(TypeError)
         expect { Greeter.new(my_person_double).greet }.not_to raise_error(TypeError)
         expect { Greeter.new(my_person_double).reversed }.not_to raise_error(TypeError)
+        expect { Greeter.new(my_person_double).person }.not_to raise_error(TypeError)
         expect { Greeter.new('Hello').greet }.to raise_error(TypeError)
         expect { Greeter.new(my_person_double).greet_others([my_person_double, another_person]) }
           .not_to raise_error(TypeError)


### PR DESCRIPTION
This PR adds support for T.cast; the message signature on the `TypeError` raised for inline type checking on `T.cast` usage is identical to `T.let`.