### PR TITLE
Turn the prefix before Double into optional

### DIFF
--- a/lib/rspec/sorbet/doubles.rb
+++ b/lib/rspec/sorbet/doubles.rb
@@ -23,16 +23,11 @@ module RSpec
       INLINE_DOUBLE_REGEX =
         /T.(let|cast): Expected type (T.(any|nilable)\()?(?<expected_classes>[a-zA-Z:: ,]*)(\))?, got type (.*) with value #<(Instance|Class|Object)Double\((?<doubled_module>[a-zA-Z:: ,]*)\)/.freeze
 
-      SIMPLE_DOUBLE_REGEX =
-        /T.(let|cast): Expected type (.*), got type RSpec::Mocks::Double with value #<?Double (.*)>/.freeze
-
       def inline_type_error_handler(error)
         case error
         when TypeError
           message = error.message
-          return if double_message_with_ellipsis?(message) || typed_array_message?(message)
-
-          return if message.match(SIMPLE_DOUBLE_REGEX)
+          return if unable_to_check_type_for_message?(message)
 
           _, expected_types_string, doubled_module_string = (message.match(INLINE_DOUBLE_REGEX) || [])[0..2]
           raise error unless expected_types_string && doubled_module_string
@@ -51,6 +46,12 @@ module RSpec
         end
       end
 
+      def unable_to_check_type_for_message?(message)
+        message_indicates_non_verifying_double?(message) ||
+          double_message_with_ellipsis?(message) ||
+            typed_array_message?(message)
+      end
+
       VERIFYING_DOUBLE_OR_DOUBLE =
         /(RSpec::Mocks::(Instance|Class|Object)VerifyingDouble|(Instance|Class|Object)?Double)/.freeze
 
@@ -64,6 +65,13 @@ module RSpec
         message.match?(TYPED_ARRAY_MESSAGE)
       end
 
+      NON_VERIFYING_DOUBLE_REGEX =
+        /got type RSpec::Mocks::Double with value #<?Double (.*)>/.freeze
+
+      def message_indicates_non_verifying_double?(message)
+        message.match(NON_VERIFYING_DOUBLE_REGEX)
+      end
+
       def call_validation_error_handler(_signature, opts)
         should_raise = true
 
@@ -73,9 +81,7 @@ module RSpec
           value = opts[:value].is_a?(Array) ? opts[:value].first : opts[:value]
           target = value.instance_variable_get(:@doubled_module)&.target
 
-          if target.nil?
-            return
-          end
+          return if target.nil?
 
           case typing
           when T::Types::TypedArray, T::Types::TypedEnumerable

--- a/lib/rspec/sorbet/doubles.rb
+++ b/lib/rspec/sorbet/doubles.rb
@@ -67,7 +67,11 @@ module RSpec
         if message.match?(VERIFYING_DOUBLE_OR_DOUBLE)
           typing = opts[:type]
           value = opts[:value].is_a?(Array) ? opts[:value].first : opts[:value]
-          target = value.instance_variable_get(:@doubled_module).target
+          target = value.instance_variable_get(:@doubled_module)&.target
+
+          if target.nil?
+            return
+          end
 
           case typing
           when T::Types::TypedArray, T::Types::TypedEnumerable

--- a/lib/rspec/sorbet/doubles.rb
+++ b/lib/rspec/sorbet/doubles.rb
@@ -21,7 +21,7 @@ module RSpec
       private
 
       INLINE_DOUBLE_REGEX =
-        /T.(let|cast): Expected type (T.(any|nilable)\()?(?<expected_classes>[a-zA-Z:: ,]*)(\))?, got type (.*) with value #<(Instance|Class|Object)?Double\((?<doubled_module>[a-zA-Z:: ,]*)\)/.freeze
+        /T.(let|cast): Expected type (T.(any|nilable)\()?(?<expected_classes>[a-zA-Z:: ,]*)(\))?, got type (.*) with value #<(Instance|Class|Object)Double\((?<doubled_module>[a-zA-Z:: ,]*)\)/.freeze
 
       SIMPLE_DOUBLE_REGEX =
         /T.(let|cast): Expected type (.*), got type RSpec::Mocks::Double with value #<?Double (.*)>/.freeze

--- a/lib/rspec/sorbet/doubles.rb
+++ b/lib/rspec/sorbet/doubles.rb
@@ -48,7 +48,7 @@ module RSpec
       end
 
       VERIFYING_DOUBLE_OR_DOUBLE =
-        /(RSpec::Mocks::(Instance|Class|Object)VerifyingDouble|(Instance|Class|Object)Double)/.freeze
+        /(RSpec::Mocks::(Instance|Class|Object)VerifyingDouble|(Instance|Class|Object)?Double)/.freeze
 
       def double_message_with_ellipsis?(message)
         message.include?('...') && message.match?(VERIFYING_DOUBLE_OR_DOUBLE)

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -144,7 +144,7 @@ module RSpec
           expect(p).to_not be nil
         end
 
-        it 'works with methods' do
+        it 'allows test doubles as method arguments' do
           expect { f(my_double) }.to raise_error(TypeError)
           subject
           expect { f(my_double) }.not_to raise_error(TypeError)

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -149,6 +149,12 @@ module RSpec
           subject
           expect { f(my_double) }.not_to raise_error(TypeError)
         end
+
+        specify do
+          expect { T.let(my_double, String) }.to raise_error(TypeError)
+          subject
+          expect { T.let(my_double, String) }.not_to raise_error(TypeError)
+        end
       end
     end
   end

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -6,8 +6,6 @@ require 'rspec/sorbet'
 
 module RSpec
   describe Sorbet do
-    extend T::Sig
-
     shared_context 'instance double' do
       class Person
         extend T::Sig
@@ -139,15 +137,19 @@ module RSpec
       describe 'doubles' do
         let(:my_double) { double('name') }
 
-        sig { params(p: String).void }
-        def f(p)
-          expect(p).to_not be nil
+        class DoubleMethodArgument
+          extend T::Sig
+
+          sig { params(message: String).void }
+          def initialize(message)
+            @message = message
+          end
         end
 
         it 'allows test doubles as method arguments' do
-          expect { f(my_double) }.to raise_error(TypeError)
+          expect { DoubleMethodArgument.new(my_double) }.to raise_error(TypeError)
           subject
-          expect { f(my_double) }.not_to raise_error(TypeError)
+          expect { DoubleMethodArgument.new(my_double) }.not_to raise_error(TypeError)
         end
 
         specify do

--- a/spec/lib/rspec/sorbet_spec.rb
+++ b/spec/lib/rspec/sorbet_spec.rb
@@ -1,10 +1,13 @@
 # typed: ignore
 # frozen_string_literal: true
 
+require 'sorbet-runtime'
 require 'rspec/sorbet'
 
 module RSpec
   describe Sorbet do
+    extend T::Sig
+
     shared_context 'instance double' do
       class Person
         extend T::Sig
@@ -130,6 +133,21 @@ module RSpec
           expect { T.let(my_object_double, String) }.to raise_error(TypeError)
           subject
           expect { T.let(my_object_double, String) }.not_to raise_error(TypeError)
+        end
+      end
+
+      describe 'doubles' do
+        let(:my_double) { double('name') }
+
+        sig { params(p: String).void }
+        def f(p)
+          expect(p).to_not be nil
+        end
+
+        it 'works with methods' do
+          expect { f(my_double) }.to raise_error(TypeError)
+          subject
+          expect { f(my_double) }.not_to raise_error(TypeError)
         end
       end
     end


### PR DESCRIPTION
RSpec::MocksExampleMethods.double() has no prefix before the `Double` in the error message

I'm not a Ruby programmer, so the code is probably horrible 😅 